### PR TITLE
use bytes regex to avoid string/bytes conflict

### DIFF
--- a/wikiteam3/dumpgenerator/util.py
+++ b/wikiteam3/dumpgenerator/util.py
@@ -68,8 +68,8 @@ def cleanXML(xml=""):
     # for Windows compatibility.
     # If the encoding has to stay as is, we'll have
     # to change all the file encodings, as well.
-    if re.search(r"</siteinfo>\n", xml):
+    if re.search(rb"</siteinfo>\n", xml):
         xml = xml.split("</siteinfo>\n")[1].encode("utf-8")
-    if re.search(r"</mediawiki>", xml):
+    if re.search(rb"</mediawiki>", xml):
         xml = xml.split("</mediawiki>")[0].encode("utf-8")
     return xml


### PR DESCRIPTION
Intended to fix #29
Haven't tested it yet, wanted to double-check with you first because of the comments discouraging messing with the encoding.
Another alternative would be to add something like `xml = xml.decode("utf-8)`