### PR TITLE
Remove dependency on argparse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ dumpgenerator = "wikiteam3.dumpgenerator:main"
 [tool.poetry.dependencies]
 python = "^3.8"
 requests = "^2.26.0"
-argparse = "^1.4.0"
 internetarchive = "^2.1.0"
 lxml = "^4.9.1"
 mwclient = "^0.10.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-argparse==1.4.0 \
-    --hash=sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314 \
-    --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4
 certifi==2021.10.8 ; python_version >= "2.7" and python_full_version < "3.0.0" or python_version >= "3.6" \
     --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569 \
     --hash=sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872


### PR DESCRIPTION
`argparse` is part of the standard library since Python 3.1. All versions prior to Python 3.1 are EOL, so this dependency is unnecessary (and causes problems, since `pip` doesn't consider it to be installed, and installs it every time it's asked to install requirements).