### PR TITLE
Bump version to 0.5.0-alpha with some improvements (Part 2)

### DIFF
--- a/wikiteam3/dumpgenerator/api.py
+++ b/wikiteam3/dumpgenerator/api.py
@@ -111,20 +111,13 @@ def mwGetAPIAndIndex(url="", session=None):
     return api, index
 
 
-def checkRetryAPI(api=None, retries=5, apiclient=False, session=None):
+def checkRetryAPI(api=None, apiclient=False, session=None):
     """Call checkAPI and mwclient if necessary"""
-    retry = 0
-    retrydelay = 20
     check = None
-    while retry < retries:
-        try:
-            check = checkAPI(api, session=session)
-            break
-        except requests.exceptions.ConnectionError as e:
-            print("Connection error: %s" % (str(e)))
-            retry += 1
-            print("Start retry attempt %d in %d seconds." % (retry + 1, retrydelay))
-            time.sleep(retrydelay)
+    try:
+        check = checkAPI(api, session=session)
+    except requests.exceptions.ConnectionError as e:
+        print("Connection error: %s" % (str(e)))
 
     if check and apiclient:
         apiurl = urlparse(api)

--- a/wikiteam3/dumpgenerator/api.py
+++ b/wikiteam3/dumpgenerator/api.py
@@ -1,6 +1,6 @@
 import re
 import time
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, urljoin
 
 import mwclient
 import requests
@@ -89,7 +89,13 @@ def mwGetAPIAndIndex(url="", session=None):
             index = m[0]
     if index:
         if index.startswith("/"):
-            index = "/".join(api.split("/")[:-1]) + "/" + index.split("/")[-1]
+            if api:
+                index = urljoin(api, index.split("/")[-1])
+            else:
+                index = urljoin(url, index.split("/")[-1])
+            #     api = index.split("/index.php")[0] + "/api.php"
+            if index.endswith("/Main_Page"):
+                index = urljoin(index, "index.php")
     else:
         if api:
             if len(re.findall(r"/index\.php5\?", result)) > len(
@@ -98,6 +104,9 @@ def mwGetAPIAndIndex(url="", session=None):
                 index = "/".join(api.split("/")[:-1]) + "/index.php5"
             else:
                 index = "/".join(api.split("/")[:-1]) + "/index.php"
+
+    if not api and index:
+        api = urljoin(index, "api.php")
 
     return api, index
 

--- a/wikiteam3/dumpgenerator/api.py
+++ b/wikiteam3/dumpgenerator/api.py
@@ -121,7 +121,7 @@ def checkRetryAPI(api=None, retries=5, apiclient=False, session=None):
         apiurl = urlparse(api)
         try:
             site = mwclient.Site(
-                apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme
+                apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme, pool=session
             )
         except KeyError:
             # Probably KeyError: 'query'
@@ -139,7 +139,7 @@ def checkRetryAPI(api=None, retries=5, apiclient=False, session=None):
 
             try:
                 site = mwclient.Site(
-                    apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=newscheme
+                    apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=newscheme, pool=session
                 )
             except KeyError:
                 check = False

--- a/wikiteam3/dumpgenerator/cli.py
+++ b/wikiteam3/dumpgenerator/cli.py
@@ -134,7 +134,7 @@ def getParameters(params=[]):
 
         # Courtesy datashaman https://stackoverflow.com/a/35504626
         __retries__ = Retry(
-            total=5, backoff_factor=2, status_forcelist=[500, 502, 503, 504, 429]
+            total=int(args.retries), backoff_factor=2, status_forcelist=[500, 502, 503, 504, 429]
         )
         session.mount("https://", HTTPAdapter(max_retries=__retries__))
         session.mount("http://", HTTPAdapter(max_retries=__retries__))

--- a/wikiteam3/dumpgenerator/cli.py
+++ b/wikiteam3/dumpgenerator/cli.py
@@ -187,7 +187,6 @@ def getParameters(params=[]):
     if api:
         check, checkedapi = checkRetryAPI(
             api=api,
-            retries=int(args.retries),
             apiclient=args.xmlrevisions,
             session=session,
         )

--- a/wikiteam3/dumpgenerator/delay.py
+++ b/wikiteam3/dumpgenerator/delay.py
@@ -12,8 +12,7 @@ class Delay:
     def animate(self):
         try:
             while not self.done:
-                sys.stdout.write("\r    " + self.ellipses)
-                sys.stdout.flush()
+                print("\r" + self.ellipses, end="")
                 self.ellipses += "."
                 time.sleep(0.1)
         except KeyboardInterrupt:
@@ -33,5 +32,5 @@ class Delay:
             time.sleep(config["delay"])
             self.done = True
 
-            sys.stdout.write("\r                           \r")
-            sys.stdout.flush()
+            spaces = int(config["delay"]/0.1)
+            print("\r"+" "*spaces,end="\r")

--- a/wikiteam3/dumpgenerator/delay.py
+++ b/wikiteam3/dumpgenerator/delay.py
@@ -32,5 +32,4 @@ class Delay:
             time.sleep(config["delay"])
             self.done = True
 
-            spaces = int(config["delay"]/0.1)
-            print("\r"+" "*spaces,end="\r")
+            print("\r"+"    ",end="\r")

--- a/wikiteam3/dumpgenerator/exceptions.py
+++ b/wikiteam3/dumpgenerator/exceptions.py
@@ -13,3 +13,19 @@ class ExportAbortedError(Exception):
 
     def __str__(self):
         return "Export from '%s' did not return anything." % self.index
+
+class FileSizeError(Exception):
+    def __init__(self, file, size):
+        self.file = file
+        self.size = size
+
+    def __str__(self):
+        return "File '%s' size is not match '%s'." % (self.file, self.size)
+
+class FileSha1Error(Exception):
+    def __init__(self, file, sha1):
+        self.file = file
+        self.sha1 = sha1
+
+    def __str__(self):
+        return "File '%s' sha1 is not match '%s'." % (self.file, self.sha1)

--- a/wikiteam3/dumpgenerator/generator.py
+++ b/wikiteam3/dumpgenerator/generator.py
@@ -27,6 +27,7 @@ from .greeter import bye, welcome
 from .image import Image
 from .index_php import saveIndexPHP
 from .logs import saveLogs
+from .log_error import logerror
 from .page_special_version import saveSpecialVersion
 from .page_titles import getPageTitles, readTitles
 from .site_info import saveSiteInfo
@@ -216,7 +217,7 @@ class DumpGenerator:
                     % (config["path"], domain2prefix(config=config), config["date"]),
                     encoding="utf-8",
                 )
-                lines = f.readlines()
+                lines = f.read().splitlines()
                 for l in lines:
                     if re.search(r"\t", l):
                         images.append(l.split("\t"))
@@ -226,6 +227,9 @@ class DumpGenerator:
                 f.close()
             except FileNotFoundError:
                 pass  # probably file does not exists
+            if len(images)>0 and len(images[0]) < 5:
+                print("Warning: Detected old image list format. You can delete 'images.txt' manually and restart the script.")
+                sys.exit(1)
             if lastimage == "--END--":
                 print("Image list was completed in the previous session")
             else:
@@ -241,22 +245,31 @@ class DumpGenerator:
             except OSError:
                 pass  # probably directory does not exist
             listdir.sort()
-            complete = True
-            lastfilename = ""
-            lastfilename2 = ""
-            c = 0
-            for filename, url, uploader in images:
-                lastfilename2 = lastfilename
+            c_desc = 0
+            c_images = 0
+            for filename, url, uploader, size, sha1 in images:
                 # return always the complete filename, not the truncated
-                lastfilename = filename
                 filename2 = filename
                 if len(filename2) > other["filenamelimit"]:
                     filename2 = truncateFilename(other=other, filename=filename2)
-                if filename2 not in listdir:
-                    complete = False
-                    break
-                c += 1
-            print("%d images were found in the directory from a previous session" % (c))
+                if filename2 in listdir:
+                    c_images += 1
+                if filename2+".desc" in listdir:
+                    c_desc += 1
+            print(f"{len(images)} records in images.txt, {c_images} images and {c_desc} .desc were saved in the previous session")
+            if c_desc < len(images):
+                complete = False
+            elif c_images < len(images):
+                complete = False
+                print("WARNING: Some images were not saved. You may want to delete their \n"
+                    +".desc files and re-run the script to redownload the missing images.\n"
+                    +"(If images URL are unavailable, you can ignore this warning.)\n"
+                    +"(In most cases, if the number of .desc files equals the number of \n"
+                    + "images.txt records, you can ignore this warning, images dump was completed.)")
+                sys.exit()
+            else: # c_desc == c_images == len(images)
+                complete = True
+            
             if complete:
                 # image dump is complete
                 print("Image dump was completed in the previous session")
@@ -267,7 +280,6 @@ class DumpGenerator:
                     config=config,
                     other=other,
                     images=images,
-                    start=lastfilename2,
                     session=other["session"],
                 )
 

--- a/wikiteam3/dumpgenerator/image.py
+++ b/wikiteam3/dumpgenerator/image.py
@@ -297,7 +297,7 @@ class Image:
             params = {
                 "action": "query",
                 "list": "allimages",
-                "aiprop": "url|user",
+                "aiprop": "url|user|size|sha1",
                 "aifrom": aifrom,
                 "format": "json",
                 "ailimit": 50,
@@ -359,7 +359,9 @@ class Image:
                             + " contains unicode. Please file an issue with WikiTeam."
                         )
                     uploader = re.sub("_", " ", image["user"])
-                    images.append([filename, url, uploader])
+                    size = image["size"]
+                    sha1 = image["sha1"]
+                    images.append([filename, url, uploader, size, sha1])
             else:
                 oldAPI = True
                 break
@@ -383,7 +385,7 @@ class Image:
                                     # TODO: Is it OK to set it higher, for speed?
                     "gapfrom": gapfrom,
                     "prop": "imageinfo",
-                    "iiprop": "user|url",
+                    "iiprop": "url|user|size|sha1",
                     "format": "json",
                 }
                 # FIXME Handle HTTP Errors HERE
@@ -427,7 +429,9 @@ class Image:
 
                         filename = re.sub("_", " ", tmp_filename)
                         uploader = re.sub("_", " ", props["imageinfo"][0]["user"])
-                        images.append([filename, url, uploader])
+                        size = props["imageinfo"][0]["size"]
+                        sha1 = props["imageinfo"][0]["sha1"]
+                        images.append([filename, url, uploader, size, sha1])
                 else:
                     # if the API doesn't return query data, then we're done
                     break
@@ -440,7 +444,7 @@ class Image:
         return images
 
     def saveImageNames(config={}, images=[], session=None):
-        """Save image list in a file, including filename, url and uploader"""
+        """Save image list in a file, including filename, url, uploader, size and sha1"""
 
         imagesfilename = "{}-{}-images.txt".format(
             domain2prefix(config=config), config["date"]
@@ -451,8 +455,8 @@ class Image:
         imagesfile.write(
             "\n".join(
                 [
-                    filename + "\t" + url + "\t" + uploader
-                    for filename, url, uploader in images
+                    filename + "\t" + url + "\t" + uploader + "\t" + str(size) + "\t" + sha1
+                    for filename, url, uploader, size, sha1 in images
                 ]
             )
         )

--- a/wikiteam3/dumpgenerator/image.py
+++ b/wikiteam3/dumpgenerator/image.py
@@ -140,7 +140,7 @@ class Image:
 
             except OSError:
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text=f"File {imagepath}/{filename2}.desc could not be created by OS",
                 )
 

--- a/wikiteam3/dumpgenerator/log_error.py
+++ b/wikiteam3/dumpgenerator/log_error.py
@@ -1,12 +1,14 @@
 import datetime
 
 
-def logerror(config={}, text=""):
-    """Log error in file"""
+def logerror(config={},to_stdout=False , text="") -> None:
+    """Log error in errors.log"""
     if text:
         with open("%s/errors.log" % (config["path"]), "a", encoding="utf-8") as outfile:
             output = "{}: {}\n".format(
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 text,
             )
-            outfile.write(str(output))
+            outfile.write(output)
+    if to_stdout:
+        print(text)

--- a/wikiteam3/dumpgenerator/page_titles.py
+++ b/wikiteam3/dumpgenerator/page_titles.py
@@ -23,7 +23,7 @@ def getPageTitlesAPI(config={}, session=None):
         sys.stdout.write("    Retrieving titles in the namespace %d" % (namespace))
         apiurl = urlparse(config["api"])
         site = mwclient.Site(
-            apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme
+            apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme, pool=session
         )
         for page in site.allpages(namespace=namespace):
             title = page.name

--- a/wikiteam3/dumpgenerator/page_titles.py
+++ b/wikiteam3/dumpgenerator/page_titles.py
@@ -10,7 +10,7 @@ from .namespaces import getNamespacesAPI, getNamespacesScraper
 from .util import cleanHTML, undoHTMLEntities
 
 
-def getPageTitlesAPI(config={}, session=None):
+def getPageTitlesAPI(config={}, session=None) -> str:
     """Uses the API to get the list of page titles"""
     titles = []
     namespaces, namespacenames = getNamespacesAPI(config=config, session=session)
@@ -52,8 +52,8 @@ def getPageTitlesScraper(config={}, session=None):
             config["index"], namespace
         )
         r = session.get(url=url, timeout=30)
-        raw = str(r.text)
-        raw = str(cleanHTML(raw))
+        raw = r.text
+        raw = cleanHTML(raw)
 
         r_title = 'title="(?P<title>[^>]+)">'
         r_suballpages = ""
@@ -219,7 +219,7 @@ def readTitles(config={}, start=None, batch=False):
 
     with titlesfile as f:
         for line in f:
-            title = str(line).strip()
+            title = str(line).strip()  # TODO: check str() is needed here
             if title == "--END--":
                 break
             elif seeking and title != start:

--- a/wikiteam3/dumpgenerator/page_xml.py
+++ b/wikiteam3/dumpgenerator/page_xml.py
@@ -55,7 +55,7 @@ def getXMLPageCore(headers={}, params={}, config={}, session=None) -> str:
                 print("    Trying to save only the last revision for this page...")
                 params["curonly"] = 1
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text='Error while retrieving the full history of "%s". Trying to save only the last revision for this page'
                     % (params["pages"]),
                 )
@@ -65,7 +65,7 @@ def getXMLPageCore(headers={}, params={}, config={}, session=None) -> str:
             else:
                 print("    Saving in the errors log, and skipping...")
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text='Error while retrieving the last revision of "%s". Skipping.'
                     % (params["pages"]),
                 )

--- a/wikiteam3/dumpgenerator/user_agent.py
+++ b/wikiteam3/dumpgenerator/user_agent.py
@@ -4,6 +4,7 @@ def getUserAgent():
         # firefox
         # 'Mozilla/5.0 (X11; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0',
         # 'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0',
-        "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0"
+        # "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0",
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:108.0) Gecko/20100101 Firefox/108.0',
     ]
     return useragents[0]

--- a/wikiteam3/dumpgenerator/util.py
+++ b/wikiteam3/dumpgenerator/util.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import sys
 
@@ -74,3 +75,15 @@ def cleanXML(xml: str = "") -> str:
     if re.search(r"</mediawiki>", xml):
         xml = xml.split("</mediawiki>")[0]
     return xml
+
+def sha1file(file: str = "") -> str:
+    """Return the SHA1 hash of a file"""
+
+    sha1 = hashlib.sha1()
+    with open(file, "rb") as f:
+        while True:
+            data = f.read(65536)
+            if not data:
+                break
+            sha1.update(data)
+    return sha1.hexdigest()

--- a/wikiteam3/dumpgenerator/version.py
+++ b/wikiteam3/dumpgenerator/version.py
@@ -1,4 +1,4 @@
-__VERSION__ = "0.4.0-alpha"  # major, minor, micro: semver.org
+__VERSION__ = "0.5.0-alpha"  # major, minor, micro: semver.org
 
 
 def getVersion():

--- a/wikiteam3/dumpgenerator/xml_dump.py
+++ b/wikiteam3/dumpgenerator/xml_dump.py
@@ -101,7 +101,7 @@ def generateXMLDump(config={}, titles=[], start=None, session=None):
                     xmlfile.write(xml)
             except PageMissingError:
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text='The page "%s" was missing in the wiki (probably deleted)'
                     % title,
                 )

--- a/wikiteam3/dumpgenerator/xml_header.py
+++ b/wikiteam3/dumpgenerator/xml_header.py
@@ -123,6 +123,6 @@ def getXMLHeader(config: dict = {}, session=None) -> tuple[str, dict]:
         else:
             print(xml)
             print("XML export on this wiki is broken, quitting.")
-            logerror("XML export on this wiki is broken, quitting.")
+            logerror(to_stdout=True, text="XML export on this wiki is broken, quitting.")
             sys.exit()
     return header, config

--- a/wikiteam3/dumpgenerator/xml_revisions.py
+++ b/wikiteam3/dumpgenerator/xml_revisions.py
@@ -18,7 +18,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
     # FIXME: force the protocol we asked for! Or don't verify SSL if we asked HTTP?
     # https://github.com/WikiTeam/wikiteam/issues/358
     site = mwclient.Site(
-        apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme
+        apiurl.netloc, apiurl.path.replace("api.php", ""), scheme=apiurl.scheme, pool=session
     )
 
     if "all" not in config["namespaces"]:

--- a/wikiteam3/dumpgenerator/xml_revisions.py
+++ b/wikiteam3/dumpgenerator/xml_revisions.py
@@ -260,7 +260,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                         )
                 except mwclient.errors.InvalidResponse:
                     logerror(
-                        config=config,
+                        config=config, to_stdout=True,
                         text="Error: page inaccessible? Could not export page: %s"
                         % ("; ".join(titlelist)),
                     )
@@ -275,7 +275,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                         pages = prequest["query"]["pages"]
                     except KeyError:
                         logerror(
-                            config=config,
+                            config=config, to_stdout=True,
                             text="Error: page inaccessible? Could not export page: %s"
                             % ("; ".join(titlelist)),
                         )
@@ -287,7 +287,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                             yield xml
                         except PageMissingError:
                             logerror(
-                                config=config,
+                                config=config, to_stdout=True,
                                 text="Error: empty revision from API. Could not export page: %s"
                                 % ("; ".join(titlelist)),
                             )


### PR DESCRIPTION
- pass requests session to mwclient (https://github.com/WikiTeam/wikiteam/pull/441, 405b32ac9612923f85d5a4da237f2b807ab49ab8)
  > FIX: #40 (not tested yet)
- FIX: **Send/Recive twice download requests to the image URL** by deleting duplicate code block.(a329903faa526176611bc43c93538ebd1c179b8c)
- add `to_stdout` parameter to `logerror()` for printing errors to stdout (0ce1d8820e6013807d0e187941047e55c4ea730f)
- FIX #23: **index url computation fails on some wikis** (94e62691c11fb301988756eb8f9d6e24c7eab536)
- make `requests.session` to use `--retries` value (0e317e213f6ca55964a255f9a9437086ebffa6af)
- remove redundant retry logic (c4c853f508f46ee44e4b138b21efe0090f5de254)
  > requests.session already has built-in retry mechanism
- **save more metadata(size, sha1) into images.txt** (30176d556311179873842da034448b58b674e302)
- introduce `sha1file()` (e8adcbef151693dc6a2d2e1c3a1c10d74517f933)
- **feat (image dump)**: (5edd3ace52035985926e0837f75a7555058904d6)
  - validate image size after requests fetched it: `if len(r.content) == size`
  - show progress and prrint more info
  - better resume:
    > > also FIX: #15
    >Improved the resume mechanism.
    >First check whether the file and file.desc exist, and then check whether the size and sha1 of the file correspond to images.txt. If any check fails, the file and the .desc of the file will be downloaded again. If all pass, the download of this file is skipped.
    >You can even delete random pictures and .desc files and try to resume again.
  - bump version to 0.5.0-alpha:
    > because the format of `images.txt` has changed.
  - pre-work for incremental image dump:
    > #51
  - remove `start` param from `generatorImageDump()`
    - the images resume mechanism has changed. we don't need `start` for resuming anymore.
- other minor improvements:
  - Change UA
  - more error log
  - ...