### PR TITLE
Logerror to stdout

### DIFF
--- a/wikiteam3/dumpgenerator/image.py
+++ b/wikiteam3/dumpgenerator/image.py
@@ -158,7 +158,7 @@ class Image:
                 f.close()
             except OSError:
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text=f"File {imagepath}/{filename2}.desc could not be created by OS",
                 )
 

--- a/wikiteam3/dumpgenerator/log_error.py
+++ b/wikiteam3/dumpgenerator/log_error.py
@@ -1,12 +1,14 @@
 import datetime
 
 
-def logerror(config={}, text=""):
-    """Log error in file"""
+def logerror(config={},to_stdout=False , text="") -> None:
+    """Log error in errors.log"""
     if text:
         with open("%s/errors.log" % (config["path"]), "a", encoding="utf-8") as outfile:
             output = "{}: {}\n".format(
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 text,
             )
-            outfile.write(str(output))
+            outfile.write(output)
+    if to_stdout:
+        print(text)

--- a/wikiteam3/dumpgenerator/page_xml.py
+++ b/wikiteam3/dumpgenerator/page_xml.py
@@ -55,7 +55,7 @@ def getXMLPageCore(headers={}, params={}, config={}, session=None) -> str:
                 print("    Trying to save only the last revision for this page...")
                 params["curonly"] = 1
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text='Error while retrieving the full history of "%s". Trying to save only the last revision for this page'
                     % (params["pages"]),
                 )
@@ -65,7 +65,7 @@ def getXMLPageCore(headers={}, params={}, config={}, session=None) -> str:
             else:
                 print("    Saving in the errors log, and skipping...")
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text='Error while retrieving the last revision of "%s". Skipping.'
                     % (params["pages"]),
                 )

--- a/wikiteam3/dumpgenerator/xml_dump.py
+++ b/wikiteam3/dumpgenerator/xml_dump.py
@@ -101,7 +101,7 @@ def generateXMLDump(config={}, titles=[], start=None, session=None):
                     xmlfile.write(xml)
             except PageMissingError:
                 logerror(
-                    config=config,
+                    config=config, to_stdout=True,
                     text='The page "%s" was missing in the wiki (probably deleted)'
                     % title,
                 )

--- a/wikiteam3/dumpgenerator/xml_header.py
+++ b/wikiteam3/dumpgenerator/xml_header.py
@@ -123,6 +123,6 @@ def getXMLHeader(config: dict = {}, session=None) -> tuple[str, dict]:
         else:
             print(xml)
             print("XML export on this wiki is broken, quitting.")
-            logerror("XML export on this wiki is broken, quitting.")
+            logerror(to_stdout=True, text="XML export on this wiki is broken, quitting.")
             sys.exit()
     return header, config

--- a/wikiteam3/dumpgenerator/xml_revisions.py
+++ b/wikiteam3/dumpgenerator/xml_revisions.py
@@ -260,7 +260,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                         )
                 except mwclient.errors.InvalidResponse:
                     logerror(
-                        config=config,
+                        config=config, to_stdout=True,
                         text="Error: page inaccessible? Could not export page: %s"
                         % ("; ".join(titlelist)),
                     )
@@ -275,7 +275,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                         pages = prequest["query"]["pages"]
                     except KeyError:
                         logerror(
-                            config=config,
+                            config=config, to_stdout=True,
                             text="Error: page inaccessible? Could not export page: %s"
                             % ("; ".join(titlelist)),
                         )
@@ -287,7 +287,7 @@ def getXMLRevisions(config={}, session=None, allpages=False, start=None):
                             yield xml
                         except PageMissingError:
                             logerror(
-                                config=config,
+                                config=config, to_stdout=True,
                                 text="Error: empty revision from API. Could not export page: %s"
                                 % ("; ".join(titlelist)),
                             )


### PR DESCRIPTION
Add `to_stdout` parameter to `logerror()` for printing errors to stdout.