### PR TITLE
Fix some bugs in #103

### DIFF
--- a/wikiteam3/dumpgenerator/api/page_titles.py
+++ b/wikiteam3/dumpgenerator/api/page_titles.py
@@ -234,7 +234,7 @@ def checkTitleOk(config: Config=None, ):
 def readTitles(config: Config=None, session=None, start=None, batch=False):
     """Read title list from a file, from the title "start" """
     if not checkTitleOk(config):
-        getPageTitles(config=config)
+        getPageTitles(config=config, session=session)
 
     titlesfilename = "{}-{}-titles.txt".format(
         domain2prefix(config=config), config.date

--- a/wikiteam3/dumpgenerator/dump/page/xmlrev/xml_revisions.py
+++ b/wikiteam3/dumpgenerator/dump/page/xmlrev/xml_revisions.py
@@ -347,7 +347,7 @@ def getXMLRevisions(config: Config=None, session=None, useAllrevision=True, last
 
     if useAllrevision:
         # Find last title
-        if lastPage:
+        if lastPage is not None:
             try:
                 lastNs = int(lastPage.find('ns').text)
                 if False:
@@ -378,7 +378,7 @@ def getXMLRevisions(config: Config=None, session=None, useAllrevision=True, last
             sys.exit()
     else:
         # Find last title
-        if lastPage:
+        if lastPage is not None:
             try:
                 start = lastPage.find('title')
             except Exception:

--- a/wikiteam3/dumpgenerator/dump/xmldump/xml_dump.py
+++ b/wikiteam3/dumpgenerator/dump/xmldump/xml_dump.py
@@ -52,7 +52,7 @@ def doXMLExportDump(config: Config=None, session=None, xmlfile=None, lastPage=No
 
     lock = True
     start = None
-    if lastPage:
+    if lastPage is not None:
         try:
             start = lastPage.find('title').text
         except Exception:

--- a/wikiteam3/dumpgenerator/dump/xmldump/xml_dump.py
+++ b/wikiteam3/dumpgenerator/dump/xmldump/xml_dump.py
@@ -54,7 +54,7 @@ def doXMLExportDump(config: Config=None, session=None, xmlfile=None, lastPage=No
     start = None
     if lastPage:
         try:
-            start = lastPage.find('title')
+            start = lastPage.find('title').text
         except Exception:
             print("Failed to find title in last trunk XML: %s" % (lxml.etree.tostring(lastPage)))
             raise


### PR DESCRIPTION
#103

Fix: `requests.session` missing
Fix: can't resume with --xml
Fix: FutureWarning in `lxml.etree` moudule