### PR TITLE
Fix: `--xmlrevisions` and `--xmlrevisions_page` can't get any wikitext

### DIFF
--- a/wikiteam3/dumpgenerator/dump/page/xmlrev/xml_revisions_page.py
+++ b/wikiteam3/dumpgenerator/dump/page/xmlrev/xml_revisions_page.py
@@ -42,9 +42,8 @@ def makeXmlFromPage(page: dict, arvcontinue) -> str:
                 E.timestamp(rev["timestamp"]),]
 
             # The text, user, comment, sha1 may be deleted/suppressed
-            if 'texthidden' or 'textmissing' in rev:
-                if 'textmissing' in rev:
-                    print("Warning: text missing in pageid %d revid %d" % (page['pageid'], rev['revid']))
+            if (('texthidden' in rev) or ('textmissing' in rev)):
+                print("Warning: text missing/hidden in pageid %d revid %d" % (page['pageid'], rev['revid']))
                 revision.append(E.text(**{
                     'bytes': str(size),
                     'deleted': 'deleted',


### PR DESCRIPTION
Fix #113

I introduced this BUG... in 0ad5475b56772db2aed134135dc0be98c5b1615c  #111 .

:-(