### PR TITLE
Fix: `indexLogin()` is not called

### DIFF
--- a/wikiteam3/dumpgenerator/cli/cli.py
+++ b/wikiteam3/dumpgenerator/cli/cli.py
@@ -162,6 +162,7 @@ def getParameters(params=None) -> Tuple[Config, Dict]:
         print("Using cookies from %s" % args.cookies)
     mod_requests_text(requests)
     session = requests.Session()
+
     try:
         from requests.adapters import HTTPAdapter
         from urllib3.util.retry import Retry
@@ -282,8 +283,8 @@ def getParameters(params=None) -> Tuple[Config, Dict]:
 
     # login if needed
     # TODO: Re-login after session regeneration.
-    if api and args.user and args.password:
-        _session = uniLogin(api=api, session=session, username=args.user, password=args.password)
+    if args.user and args.password:
+        _session = uniLogin(api=api, index=index, session=session, username=args.user, password=args.password)
         if _session:
             session = _session
             print("-- Login OK --")

--- a/wikiteam3/utils/login/__init__.py
+++ b/wikiteam3/utils/login/__init__.py
@@ -17,17 +17,20 @@ def uniLogin(api: str = '', index: str = '' ,session: requests.Session = request
         return None
 
     if api:
+        print("Trying to log in to the wiki using clientLogin... (MW 1.27+)")
         _session = clientLogin(api=api, session=session, username=username, password=password)
         if _session:
             return _session
         time.sleep(5)
 
+        print("Trying to log in to the wiki using botLogin... (MW 1.27+)")
         _session = botLogin(api=api, session=session, username=username, password=password)
         if _session:
             return _session
         time.sleep(5)
 
     if index:
+        print("Trying to log in to the wiki using indexLogin... (generic)")
         _session = indexLogin(index=index, session=session, username=username, password=password)
         if _session:
             return _session


### PR DESCRIPTION
I forgot to pass `index` var to `uniLogin()`.  (#124) 

This causes MW versions below 1.27 to be unable to log in.