### PR TITLE
Fix: `--append_date` uploads to multiple IA items

### DIFF
--- a/wikiteam3/uploader.py
+++ b/wikiteam3/uploader.py
@@ -107,12 +107,13 @@ def upload(wikis, logfile, config={}, uploadeddumps=[]):
                 # break
 
         c = 0
+        identifier = "wiki-" + wikiname
+        item = get_item(identifier)
+        first_item_exists = item.exists
         for dump in dumps:
             wikidate = dump.name.split("-")[1]
-            identifier = "wiki-" + wikiname
-            item = get_item(identifier)
-            if item.exists and config.append_date and not config.admin:
-                identifier += "-" + wikidate
+            if first_item_exists and config.append_date and not config.admin:
+                identifier = "wiki-" + wikiname  + "-" + wikidate
                 item = get_item(identifier)
             if dump.name in uploadeddumps:
                 if config.prune_directories:

--- a/wikiteam3/uploader.py
+++ b/wikiteam3/uploader.py
@@ -323,6 +323,12 @@ def upload(wikis, logfile, config={}, uploadeddumps=[]):
                     verbose=True,
                     queue_derive=False,
                 )
+                retry = 20
+                while not item.exists and retry > 0:
+                    retry -= 1
+                    print('Waitting for item "%s" to be created... (%s)' % (identifier, retry))
+                    time.sleep(10)
+                    item = get_item(identifier)
                 item.modify_metadata(md)  # update
                 print(
                     "You can find it in https://archive.org/details/%s"


### PR DESCRIPTION
* Fix: #139 
* Waiting for item to be created before modifying metadata.
    > to avoid `item.modify_metadata()` raising error (like `Unable to locate identifier`).