### PR TITLE
Fix: exporting via `--xmlreisions_page`

### DIFF
--- a/wikiteam3/dumpgenerator/api/page_titles.py
+++ b/wikiteam3/dumpgenerator/api/page_titles.py
@@ -244,7 +244,7 @@ def readTitles(config: Config=None, session=None, start=None, batch=False):
 
     titlelist = []
     seeking = False
-    if start:
+    if start is not None:
         seeking = True
 
     with titlesfile as f:

--- a/wikiteam3/dumpgenerator/dump/page/xmlexport/page_xml_api.py
+++ b/wikiteam3/dumpgenerator/dump/page/xmlexport/page_xml_api.py
@@ -40,6 +40,7 @@ def reconstructRevisions(root=None):
                 comment.set('deleted','deleted')
 
             # some revision does not return model and format, so just use hard-code
+            # TODO: not hard-code here
             ET.SubElement(rev_,'model').text = 'wikitext'
             ET.SubElement(rev_,'format').text = 'text/x-wiki'
             text = ET.SubElement(rev_,'text')
@@ -134,7 +135,14 @@ def getXMLPageWithApi(config: Config=None, title="", verbose=True, session=None)
     if not config.curonly:
         params = {'titles': title_, 'action': 'query', 'format': 'xml',
                   'prop': 'revisions',
-                  'rvprop': 'timestamp|user|comment|content|ids|userid|sha1|size|flags',
+                  'rvprop': # rvprop: <https://www.mediawiki.org/wiki/API:Revisions#Parameter_history>
+                            'timestamp|user|comment|content' # MW v????
+                            'ids|flags|size|' # MW v1.11
+                            'userid|' # MW v1.17
+                            'sha1|' # MW v1.19
+                            'contentmodel|' # MW v1.21
+                            ,
+
                   'rvcontinue': None,
                   'rvlimit': config.api_chunksize
                   }

--- a/wikiteam3/dumpgenerator/dump/page/xmlrev/xml_revisions.py
+++ b/wikiteam3/dumpgenerator/dump/page/xmlrev/xml_revisions.py
@@ -271,7 +271,7 @@ def getXMLRevisionsByTitles(config: Config=None, session=None, site: mwclient.Si
                 "action": "query",
                 "titles": "|".join(titlelist),
                 "prop": "revisions",
-                # 'rvlimit': 50,
+                'rvlimit': config.api_chunksize,
                 "rvprop": "ids|timestamp|user|userid|size|sha1|contentmodel|comment|content",
             }
             try:
@@ -326,7 +326,7 @@ def getXMLRevisionsByTitles(config: Config=None, session=None, site: mwclient.Si
                 # Get next batch of revisions if there's more.
                 if "continue" in prequest.keys():
                     print("Getting more revisions for the page")
-                    for key, value in prequest["continue"]:
+                    for key, value in prequest["continue"].items():
                         pparams[key] = value
                 elif "query-continue" in prequest.keys():
                     rvstartid = prequest["query-continue"]["revisions"]["rvstartid"]


### PR DESCRIPTION
* fix exporting via --xmlreisions_page (upstream: https://github.com/WikiTeam/wikiteam/pull/462)
* `getXMLPageWithAPI()`: pass `contentmodel` to `rvprop` for future purposes
* fix: `lxml.etree._Element: FutureWarning`. 