### PR TITLE
Code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement (at the moment, only the administrator, Elsie Hupp)
+directly via email at [mediawiki-client-tools@elsiehupp.com](mailto:mediawiki-client-tools@elsiehupp.com) or on Matrix at [@elsiehupp:beeper.com](https://matrix.to/#/@elsiehupp:beeper.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,7 @@ While it isn't the end of the world if you use the default suggested branch name
 
 ### 4. Commit your changes
 
-While there isn't really the space here to explain the technical process of Git commits, it can be helpful if you follow [some best practices](https://cbea.ms/git-commit/) with your commit messages.
-
-You don't have to do so up front, but we ask that you do so when you...
+While there isn't really the space here to explain the technical process of Git commits, it can be helpful if you follow [some best practices](https://cbea.ms/git-commit/) with your commit messages. You don't have to do so up front, but we ask that you follow these best practices for writing a commit message when you open a pull request.
 
 ### 5. Open a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Thank you for helping to improve `mediawiki-client-tools`. We're glad you're here!
+
+This document is an ongoing process for establishing and refining a set of best practices. Most of the things here are flexible or open to further iteration.
+
+## Reporting Issues
+
+If you find anything amiss, you can report it using [GitHub Issues](https://github.com/mediawiki-client-tools/mediawiki-scraper/issues). The template is there to help you communicate clearly. It's okay if you change it to meet your needs, though, as it is merely a suggested baseline.
+
+For anything that doesn't fit, you can open a less formal conversation in [GitHub Discussions](https://github.com/orgs/mediawiki-client-tools/discussions) and feel free to tag any of the members of our GitHub organization.
+
+If you wish to keep your concerns private, you can contact the organization administrator directly via email at [mediawiki-client-tools@elsiehupp.com](mailto:mediawiki-client-tools@elsiehupp.com) or on Matrix at [@elsiehupp:beeper.com](https://matrix.to/#/@elsiehupp:beeper.com).
+
+## Tools
+
+GitHub is a fancy frontend built on top of [Git](https://git-scm.com/) source control, and there is an official [Git Book](https://git-scm.com/book) you can read, skim, or search to familiarize yourself with Git, in particular.
+
+GitHub also has its own [introduction to Git](https://docs.github.com/en/get-started/using-git) as part of its [Getting Started Guide](https://docs.github.com/get-started), as well as much more extensive [documentation](https://docs.github.com) on how to use the site.
+
+Git can be counterintuitive, and [GitHub Desktop](https://desktop.github.com/) on macOS and Windows can be a friendlier and more approachable interface for using it.
+
+[Visual Studio Code](https://code.visualstudio.com/) ("VSCode") is a convenient development environment that integrates with GitHub. You can use any environment you'd like, though this is among the easiest.
+
+VSCode has [a guide to source control](https://code.visualstudio.com/docs/sourcecontrol/overview), and it has [an extension for working with GitHub](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) which you may also find convenient.
+
+In addition to the tools listed in the basic installation instructions in the main [README](./README.md), you can install [`pre-commit`](https://pre-commit.com/) in order to check and verify your work before submitting it.
+
+## Contributing Code
+
+`mediawiki-client-tools` has implemented a basic code-review and continuous-integration process which we are working to improve. With the following steps you can help us incorporate your work into our common codebase.
+
+### 1. Fork the repository if you don't have write access
+
+You can do so [here](https://github.com/mediawiki-client-tools/mediawiki-scraper/fork).
+
+### 2. Clone the repository (or your fork) if you'd like to work on it locally (such as in VS Code)
+
+This is particularly important if you are contributing executible code, so that you can use "code intelligence" and test your work. You can clone the repository using the big green **Code** button on the homepage of the repository (or your fork).
+
+Alternately, you can [create a codespace](https://github.com/mediawiki-client-tools/mediawiki-scraper/codespaces) (also from the big green **Code** button), though we have yet to set up a consistent development container.
+
+### 3. Create a new branch for the changes you'd like to make
+
+It is helpful if you use a separate branch for each task, in order to keep your Pull Requests narrowly focused so that they are easier to review.
+
+See the GitHub Desktop or VSCode documentation for how to create a new branch with either of these tools. If you are using GitHub's web-based editor, you will be prompted to do so when you click the big green **Commit changes...** button in the upper right.
+
+While it isn't the end of the world if you use the default suggested branch name, it can be helpful if you use something slightly more memorable like `fix-infinite-loop-bug` or `update-contribution-guidelines` ;-) to make it easier for code reviewers to check out your changes.
+
+### 4. Commit your changes
+
+While there isn't really the space here to explain the technical process of Git commits, it can be helpful if you follow [some best practices](https://cbea.ms/git-commit/) with your commit messages.
+
+You don't have to do so up front, but we ask that you do so when you...
+
+### 5. Open a Pull Request
+
+> **Note:** If you use a single commit when opening a Pull Request, GitHub will automatically use the commit message to populate the text fields.
+
+While we don't currently have a Pull Request template (as we do with Issues), it helps if you do the following (in no particular order):
+
+* Please keep your Pull Requests as narrowly focused as possible in order to facilitate code review. If you have multiple unrelated commits, it would probably work better if you manage each one on a separate branch and as separate Pull Requests.
+* If you don't want to squash your commits on merge, you should probably open them as separate Pull Requests instead.
+* If your Pull Request isn't solving an Issue, you may consider opening one first (and using the template there to explain your rationale). You can feel free to explain if you are planning on solving the Issue yourself.
+* If your Pull Request will help close an issue, please link to it in the text.
+* It is helpful if you tick the box reading "allow maintainers to edit" so that we can collaborate directly on the code with you.
+* If you haven't previously contributed, please add your name to the "Contributors" section at the bottom of the main [README](./README.md).
+
+## Reviewing Code
+
+If you have made a helpful contribution in the past, we may invite you to become a member of the `mediawiki-client-tools` GitHub organization.
+
+In addition to allowing you to create and edit branches directly on this repository, being a member of the organization will allow you to review and approve other people's Pull Requests.
+
+While there are certain hardcoded prerequisites in place before a Pull Request can be merged, you should also use your discretion and invite other contibutors to discuss if you think any changes may be controversial or disruptive.
+
+---
+
+Thank you again for your help!

--- a/README.md
+++ b/README.md
@@ -377,7 +377,6 @@ At the moment the only person responsible for reviewing CoC reports is the repos
 
 You can contact Elsie Hupp directly via email at [mediawiki-client-tools@elsiehupp.com](mailto:mediawiki-client-tools@elsiehupp.com) or on Matrix at [@elsiehupp:beeper.com](https://matrix.to/#/@elsiehupp:beeper.com). (Please state up front if your message concerns the Code of Conduct, as these messages are confidential.)
 
-
 ## Contributors
 
 **WikiTeam** is the [Archive Team](http://www.archiveteam.org) [[GitHub](https://github.com/ArchiveTeam)] subcommittee on wikis.

--- a/README.md
+++ b/README.md
@@ -356,28 +356,18 @@ You should see something similar to this (not the actual numbers) - the first th
 
 If your first three numbers or your last two numbers are different, then, your XML dump is corrupt (it contains one or more unfinished ```</page>``` or ```</revision>```). This is not common in small wikis, but large or very large wikis may fail at this due to truncated XML pages while exporting and merging. The solution is to remove the XML dump and re-download, a bit boring, and it can fail again.
 
-## Getting help
-
-* You can read and post in MediaWiki Client Tools' [GitHub Discussions.]( https://github.com/orgs/mediawiki-client-tools/discussions)
-* If you need help (other than reporting a bug), you can reach out on MediaWiki Client Tools' [Discussions/Q&A.](https://github.com/orgs/mediawiki-client-tools/discussions/categories/q-a)
-
-## Reporting issues
-
-Please report any issues at [MediaWiki Scraper/issues](https://github.com/mediawiki-client-tools/mediawiki-scraper/issues)
-Include the following in your report:
-
-* The commandline you used, with full URL
-* Dumpgenerator version, -v option
-* Operating system version, e.g. Kubuntu 23.04 / Windows 10
-* File system, e.g. EXT4 / NTFS
-* Name of the terminal, e.g. Bash / CMD / Powershell
-* Python version, e.g. Python 3.11.4 / Python 3.10
-* The errors.log file, from the dump folder
-* Stdout, copy the text from the terminal window
-
 ## Publishing the dump
 
 Please consider publishing your wiki dump(s). You can do it yourself as explained at WikiTeam's [Publishing the dump](https://github.com/WikiTeam/wikiteam/wiki/Tutorial#Publishing_the_dump) tutorial.
+
+## Getting help
+
+* You can read and post in MediaWiki Client Tools' [GitHub Discussions]( https://github.com/orgs/mediawiki-client-tools/discussions).
+* If you need help (other than reporting a bug), you can reach out on MediaWiki Client Tools' [Discussions/Q&A](https://github.com/orgs/mediawiki-client-tools/discussions/categories/q-a).
+
+## Contributing
+
+For information on reporting bugs and proposing changes, please see the [Contributing](./Contributing.md) guide.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,14 @@ Please consider publishing your wiki dump(s). You can do it yourself as explaine
 
 For information on reporting bugs and proposing changes, please see the [Contributing](./Contributing.md) guide.
 
+## Code of Conduct
+
+`mediawiki-client-tools` is currently working to implement the [Contributor Covenant](https://www.contributor-covenant.org), and you can read our [Code of Conduct](./CODE_OF_CONDUCT.md) based on this.
+
+At the moment the only person responsible for reviewing CoC reports is the repository administrator, Elsie Hupp, but we will work towards implementing a broader-based approach to reviews.
+
+You can contact Elsie Hupp directly via email at [mediawiki-client-tools@elsiehupp.com](mailto:mediawiki-client-tools@elsiehupp.com) or on Matrix at [@elsiehupp:beeper.com](https://matrix.to/#/@elsiehupp:beeper.com). (Please state up front if your message concerns the Code of Conduct, as these messages are confidential.)
+
 ## Contributors
 
 **WikiTeam** is the [Archive Team](http://www.archiveteam.org) [[GitHub](https://github.com/ArchiveTeam)] subcommittee on wikis.


### PR DESCRIPTION
Fixes https://github.com/mediawiki-client-tools/mediawiki-scraper/issues/82.

This branch is based on https://github.com/mediawiki-client-tools/mediawiki-scraper/pull/177, so it cannot be merged before the CONTRIBUTING branch is merged.

Note that I believe it is less than ideal for me, Elsie Hupp, to have sole responsibility for CoC reports, but I also think it's better to have an initial framework in place rather than none at all.