### PR TITLE
Support wikis that have an incorrectly configured DH key

### DIFF
--- a/wikiteam3/dumpgenerator/cli/cli.py
+++ b/wikiteam3/dumpgenerator/cli/cli.py
@@ -230,6 +230,7 @@ def getParameters(params=None) -> Tuple[Config, Dict]:
     if args.insecure:
         session.verify = False
         requests.packages.urllib3.disable_warnings()
+        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'
         print("WARNING: SSL certificate verification disabled")
 
     # Custom session retry


### PR DESCRIPTION
This makes the tool work on https://kol.coldfront.net/thekolwiki, for example