### PR TITLE
.md link to caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please consider publishing your wiki dump(s). You can do it yourself as explaine
 
 ## Contributing
 
-For information on reporting bugs and proposing changes, please see the [Contributing](./Contributing.md) guide.
+For information on reporting bugs and proposing changes, please see the [Contributing](./CONTRIBUTING.md) guide.
 
 ## Code of Conduct
 

--- a/wikiteam3/dumpgenerator/cli/cli.py
+++ b/wikiteam3/dumpgenerator/cli/cli.py
@@ -230,7 +230,7 @@ def getParameters(params=None) -> Tuple[Config, Dict]:
     if args.insecure:
         session.verify = False
         requests.packages.urllib3.disable_warnings()
-        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'
+        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = "ALL:@SECLEVEL=1"
         print("WARNING: SSL certificate verification disabled")
 
     # Custom session retry


### PR DESCRIPTION
One intra-documentation link gave me a 404 so I updated it to the filename. All other markdown links look ok.