### PR TITLE
[Backport] Add option to disable image file size check (close #170)

### DIFF
--- a/wikiteam3/dumpgenerator/cli/cli.py
+++ b/wikiteam3/dumpgenerator/cli/cli.py
@@ -130,6 +130,11 @@ def getArgumentParser():
         help="Bypass CDN image compression. (CloudFlare Polish, etc.)",
     )
     groupDownload.add_argument(
+        "--disable-image-verify",
+        action="store_true",
+        help="Don't verify image size and hash while downloading. (useful for wikis with server-side image resizing)"
+    )
+    groupDownload.add_argument(
         "--namespaces",
         metavar="1,2,3",
         help="comma-separated value of namespaces to include (all by default)",
@@ -469,6 +474,7 @@ def getParameters(params=None) -> Tuple[Config, Dict]:
         "session": session,
         "stdout_log_path": args.stdout_log_path,
         "bypass_cdn_image_compression": args.bypass_cdn_image_compression,
+        "disable_image_verify": args.disable_image_verify,
     }
 
     # calculating path, if not defined by user with --path=

--- a/wikiteam3/dumpgenerator/cli/cli.py
+++ b/wikiteam3/dumpgenerator/cli/cli.py
@@ -132,7 +132,7 @@ def getArgumentParser():
     groupDownload.add_argument(
         "--disable-image-verify",
         action="store_true",
-        help="Don't verify image size and hash while downloading. (useful for wikis with server-side image resizing)"
+        help="Don't verify image size and hash while downloading. (useful for wikis with server-side image resizing)",
     )
     groupDownload.add_argument(
         "--namespaces",

--- a/wikiteam3/dumpgenerator/dump/image/image.py
+++ b/wikiteam3/dumpgenerator/dump/image/image.py
@@ -131,7 +131,11 @@ class Image:
 
                 if r.status_code == 200:
                     try:
-                        if size == "False" or len(r.content) == int(size) or disable_image_verify:
+                        if (
+                            size == "False"
+                            or len(r.content) == int(size)
+                            or disable_image_verify
+                        ):
                             # size == 'False' means size is unknown
                             with open(filename3, "wb") as imagefile:
                                 imagefile.write(r.content)

--- a/wikiteam3/dumpgenerator/dump/image/image.py
+++ b/wikiteam3/dumpgenerator/dump/image/image.py
@@ -48,6 +48,7 @@ class Image:
         c_savedImageDescs = 0
 
         bypass_cdn_image_compression: bool = other["bypass_cdn_image_compression"]
+        disable_image_verify: bool = other["disable_image_verify"]
 
         def modify_params(params: Optional[Dict] = None) -> Dict:
             """bypass Cloudflare Polish (image optimization)"""
@@ -130,7 +131,7 @@ class Image:
 
                 if r.status_code == 200:
                     try:
-                        if size == "False" or len(r.content) == int(size):
+                        if size == "False" or len(r.content) == int(size) or disable_image_verify:
                             # size == 'False' means size is unknown
                             with open(filename3, "wb") as imagefile:
                                 imagefile.write(r.content)


### PR DESCRIPTION
This commit is backport from [saveweb/wikiteam3](https://github.com/saveweb/wikiteam3) all credit goes to the original author.

Close #170 
Fix size mismatch error when some wiki do server-side image resizing/compression without re-upload/update data in wiki.