### PR TITLE
Fix error in commit 265855d

### DIFF
--- a/wikiteam3/dumpgenerator/dump/misc/site_info_test.py
+++ b/wikiteam3/dumpgenerator/dump/misc/site_info_test.py
@@ -8,10 +8,10 @@ from wikiteam3.dumpgenerator.test.test_config import get_config
 from .site_info import saveSiteInfo
 
 
-def test_mediawiki_1_16():
-    with get_config("1.16.5") as config:
+def test_mediawiki_version_match():
+    with get_config("1.39.5") as config:
         sess = requests.Session()
         saveSiteInfo(config, sess)
         with open(f"{config.path}/siteinfo.json") as f:
             siteInfoJson = json.load(f)
-        assert siteInfoJson["query"]["general"]["generator"] == "MediaWiki 1.16.5"
+        assert siteInfoJson["query"]["general"]["generator"] == "MediaWiki 1.39.5"


### PR DESCRIPTION
In commit 265855d, I forget to change MediaWiki version in site_info_test.py so this commit fix this problem.

Also I change function name in this file from `test_mediawiki_1_16` to `test_mediawiki_version_match` to make it clear what it really does.