### PR TITLE
Fix pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 2.3.2
     hooks:
     -   id: poetry-check
-    -   id: poetry-lock
+        args: ["--lock"]
 -   repo: https://github.com/python-poetry/poetry-plugin-export
     rev: 1.10.0
     hooks:


### PR DESCRIPTION
Per https://github.com/pre-commit-ci/issues/issues/189 this configuration is necessary to deal with pre-commit CI nodes not having network access.